### PR TITLE
Allow to pass additional parameters to Shell navigation

### DIFF
--- a/samples/ControlGallery/Models/NavigationParameterModel.cs
+++ b/samples/ControlGallery/Models/NavigationParameterModel.cs
@@ -1,0 +1,11 @@
+﻿// Copyright (c) Microsoft Corporation.
+// Licensed under the MIT license.
+
+namespace ControlGallery.Models
+{
+    public class NavigationParameterModel
+    {
+        public string Name { get; set; }
+        public string Value { get; set; }
+    }
+}

--- a/samples/ControlGallery/Views/NavigationSource.razor
+++ b/samples/ControlGallery/Views/NavigationSource.razor
@@ -1,4 +1,5 @@
 ﻿@page "/navigation"
+@using ControlGallery.Models
 @inject ShellNavigationManager NavigationManager
 
 <ContentPage>
@@ -15,6 +16,7 @@
             <Button Text="Navigate with Guid" OnClick="NavigateWithGuid"></Button>
             <Button Text="Navigate with Nullable<Guid>" OnClick="NavigateWithNullableGuid"></Button>
             <Button Text="Navigate with Bool" OnClick="NavigateWithBool"></Button>
+            <Button Text="Navigate with query parameters" OnClick="NavigateWithAdditionalParameters"></Button>
         </StackLayout>
     </ScrollView>
 </ContentPage>
@@ -32,4 +34,10 @@
     async Task NavigateWithGuid() => await NavigationManager.NavigateToAsync($"/guid/{Guid.NewGuid()}");
     async Task NavigateWithNullableGuid() => await NavigationManager.NavigateToAsync($"/nullable-guid/{Guid.NewGuid()}");
     async Task NavigateWithBool() => await NavigationManager.NavigateToAsync("/bool/true");
+
+    async Task NavigateWithAdditionalParameters() => await NavigationManager.NavigateToAsync("/target", new Dictionary<string, object>
+        {
+            ["Query1"] = new NavigationParameterModel { Name = "Q1", Value = "V1" },
+            ["Query2"] = new NavigationParameterModel { Name = "Q2", Value = null }
+        });
 }

--- a/samples/ControlGallery/Views/NavigationTarget.razor
+++ b/samples/ControlGallery/Views/NavigationTarget.razor
@@ -9,6 +9,7 @@
 @page "/guid/{Guid}"
 @page "/nullable-guid/{NullableGuid}"
 @page "/bool/{Bool}"
+@using ControlGallery.Models
 
 <ContentPage>
     <StackLayout>
@@ -26,6 +27,8 @@
         <Label Text="@($"Guid = {Guid}")"></Label>
         <Label Text="@($"Guid? = {NullableGuid}")"></Label>
         <Label Text="@($"Bool = {Bool}")"></Label>
+        <Label Text="@($"Query1 = Name:{Query1?.Name}, Value:{Query1?.Value}")"></Label>
+        <Label Text="@($"Query2 = Name:{Query2?.Name}, Value:{Query2?.Value}")"></Label>
     </StackLayout>
 </ContentPage>
 
@@ -41,6 +44,6 @@
     [Parameter] public Guid Guid { get; set; }
     [Parameter] public Guid? NullableGuid { get; set; }
     [Parameter] public bool Bool { get; set; }
-
-
+    [Parameter] public NavigationParameterModel Query1 { get; set; }
+    [Parameter] public NavigationParameterModel Query2 { get; set; }
 }

--- a/src/BlazorBindings.Maui/ShellNavigation/MBBRouteFactory.cs
+++ b/src/BlazorBindings.Maui/ShellNavigation/MBBRouteFactory.cs
@@ -8,7 +8,7 @@ using MC = Microsoft.Maui.Controls;
 namespace BlazorBindings.Maui.ShellNavigation
 {
     //Based on the forms TypeRouteFactory https://github.com/xamarin/Xamarin.Forms/blob/9fd882e6c598a51bffbbb2f4de72c3bd9023ab41/Xamarin.Forms.Core/Routing.cs
-    public class MBBRouteFactory : MC.RouteFactory
+    internal class MBBRouteFactory : MC.RouteFactory
     {
         private readonly Type _componentType;
         private readonly ShellNavigationManager _navigationManager;

--- a/src/BlazorBindings.Maui/ShellNavigation/ShellNavigationManager.cs
+++ b/src/BlazorBindings.Maui/ShellNavigation/ShellNavigationManager.cs
@@ -65,14 +65,14 @@ namespace BlazorBindings.Maui
         }
 
 #pragma warning disable CA1054 // Uri parameters should not be strings
-        public void NavigateTo(string uri)
+        public void NavigateTo(string uri, Dictionary<string, object> parameters = null)
 #pragma warning restore CA1054 // Uri parameters should not be strings
         {
-            _ = NavigateToAsync(uri);
+            _ = NavigateToAsync(uri, parameters);
         }
 
 #pragma warning disable CA1054 // Uri parameters should not be strings
-        public async Task NavigateToAsync(string uri)
+        public async Task NavigateToAsync(string uri, Dictionary<string, object> parameters = null)
 #pragma warning restore CA1054 // Uri parameters should not be strings
         {
             if (uri is null)
@@ -80,7 +80,7 @@ namespace BlazorBindings.Maui
                 throw new ArgumentNullException(nameof(uri));
             }
 
-            var route = StructuredRoute.FindBestMatch(uri, Routes);
+            var route = StructuredRoute.FindBestMatch(uri, Routes, parameters);
 
             if (route != null)
             {
@@ -110,8 +110,24 @@ namespace BlazorBindings.Maui
 
             var renderer = serviceProvider.GetRequiredService<MauiBlazorBindingsRenderer>();
 
-            var convertedParameters = ConvertParameters(componentType, route.Parameters);
-            var addComponentTask = renderer.AddComponent(componentType, container, convertedParameters);
+            var parameters = ConvertParameters(componentType, route.PathParameters);
+
+            if (route.AdditionalParameters is not null)
+            {
+                if (parameters is null)
+                {
+                    parameters = route.AdditionalParameters;
+                }
+                else
+                {
+                    foreach (var (key, value) in route.AdditionalParameters)
+                    {
+                        parameters.Add(key, value);
+                    }
+                }
+            }
+
+            var addComponentTask = renderer.AddComponent(componentType, container, parameters);
             var elementAddedTask = container.WaitForElementAsync();
 
             await Task.WhenAny(addComponentTask, elementAddedTask).ConfigureAwait(false);


### PR DESCRIPTION
Fixes #11 .

Example:

```csharp
await NavigationManager.NavigateToAsync("/target", new Dictionary<string, object>
        {
            ["Query1"] = new NavigationParameterModel { Name = "Q1", Value = "V1" },
            ["Query2"] = new NavigationParameterModel { Name = "Q2", Value = null }
        });
```

```razor
... 

    [Parameter] public NavigationParameterModel Query1 { get; set; }
    [Parameter] public NavigationParameterModel Query2 { get; set; }
```