### PR TITLE
Performance improvement for DataTemplates

### DIFF
--- a/src/BlazorBindings.Maui/Elements/DataTemplates/DataTemplateItemComponent.cs
+++ b/src/BlazorBindings.Maui/Elements/DataTemplates/DataTemplateItemComponent.cs
@@ -12,13 +12,14 @@ namespace BlazorBindings.Maui.Elements.DataTemplates
     internal class DataTemplateItemComponent<T> : ComponentBase
 #pragma warning restore CA1812 // Avoid uninstantiated internal classes
     {
-        private MC.VerticalStackLayout _contentView;
+        private MC.BindableObject _contentView;
         private object _item;
+        private bool _shouldRender = true;
 
         [Parameter] public RenderFragment<T> Template { get; set; }
 
         [Parameter]
-        public MC.VerticalStackLayout ContentView
+        public MC.BindableObject ContentView
         {
             get
             {
@@ -41,11 +42,20 @@ namespace BlazorBindings.Maui.Elements.DataTemplates
             }
         }
 
+        protected override bool ShouldRender()
+        {
+            // Re-rendering is required only if BindingContext is changed.
+            // If this method is not overridden, it re-renders all items in DataTemplateItemsComponent
+            // when new item is added there.
+            return _shouldRender;
+        }
+
         protected override void BuildRenderTree(RenderTreeBuilder builder)
         {
             if (_item != null)
             {
                 builder.AddContent(0, Template.Invoke((T)_item));
+                _shouldRender = false;
             }
         }
 
@@ -59,6 +69,7 @@ namespace BlazorBindings.Maui.Elements.DataTemplates
                 if (newItem != null && newItem != _item)
                 {
                     _item = newItem;
+                    _shouldRender = true;
                     StateHasChanged();
                 }
             };

--- a/src/BlazorBindings.Maui/Elements/DataTemplates/DataTemplateItemsComponent.cs
+++ b/src/BlazorBindings.Maui/Elements/DataTemplates/DataTemplateItemsComponent.cs
@@ -41,10 +41,11 @@ namespace BlazorBindings.Maui.Elements.DataTemplates
 
         private readonly List<MC.VerticalStackLayout> _itemRoots = new();
 
-        public void Add(MC.VerticalStackLayout templateRoot)
+        public MC.View AddTemplateRoot()
         {
+            var templateRoot = new MC.VerticalStackLayout();
             _itemRoots.Add(templateRoot);
-            StateHasChanged();
+            return templateRoot;
         }
     }
 }

--- a/src/BlazorBindings.Maui/Elements/DataTemplates/MbbDataTemplate.cs
+++ b/src/BlazorBindings.Maui/Elements/DataTemplates/MbbDataTemplate.cs
@@ -7,13 +7,8 @@ namespace BlazorBindings.Maui.Elements.DataTemplates
 {
     internal class MbbDataTemplate<T> : MC.DataTemplate
     {
-        public MbbDataTemplate(DataTemplateItemsComponent<T> dataTemplateItemsAccessor)
-            : base(() =>
-            {
-                var itemRootView = new MC.VerticalStackLayout();
-                dataTemplateItemsAccessor.Add(itemRootView);
-                return itemRootView;
-            })
+        public MbbDataTemplate(DataTemplateItemsComponent<T> dataTemplateItemsContainer)
+            : base(dataTemplateItemsContainer.AddTemplateRoot)
         {
         }
     }


### PR DESCRIPTION
Currently all DataTemplate items in DataTemplateItemsComponent are re-rendered when new item is added to DataTemplateItemsComponent.
This PR overrides ShouldRender method for DataTemplateItemComponent to prevent that.