### PR TITLE
Update NativeControlComponentBase to implement IComponent directly

### DIFF
--- a/src/BlazorBindings.Maui/Elements/BindableObject.cs
+++ b/src/BlazorBindings.Maui/Elements/BindableObject.cs
@@ -23,8 +23,8 @@ namespace BlazorBindings.Maui.Elements
             {
                 HandleParameter(parameterValue.Name, parameterValue.Value);
             }
-
-            return base.SetParametersAsync(ParameterView.Empty);
+            StateHasChanged();
+            return Task.CompletedTask;
         }
 
         protected sealed override void RenderAttributes(AttributesBuilder builder)

--- a/src/BlazorBindings.Maui/Elements/Shell.cs
+++ b/src/BlazorBindings.Maui/Elements/Shell.cs
@@ -57,11 +57,10 @@ namespace BlazorBindings.Maui.Elements
 
         [Parameter] public RenderFragment ChildContent { get; set; }
 
-        // <summary>
-        // Defines the background color in the Shell chrome. The color will not fill in behind the Shell content.
-        // </summary>
-        // Cannot add 'new' properties.
-        //[Parameter] public Color BackgroundColor { get; set; }
+        /// <summary>
+        /// Defines the background color in the Shell chrome. The color will not fill in behind the Shell content.
+        /// </summary>
+        [Parameter] public new Color BackgroundColor { get; set; }
 
         /// <summary>
         /// Defines the color to shade text and icons that are disabled.


### PR DESCRIPTION
ComponentBase defines a lot of things which are not really applicable for native components, but makes them a bit slower (e.g. due to reflection in SetParametersAsync), and make some things harder (e.g. does not allow to define `new` parameters).

It makes sense to implement IComponent directly, leaving only the required bare minimum.