### PR TITLE
Make MauiBlazorBindingsRenderer a singleton

### DIFF
--- a/src/BlazorBindings.Core/NativeComponentRenderer.cs
+++ b/src/BlazorBindings.Core/NativeComponentRenderer.cs
@@ -6,6 +6,7 @@ using Microsoft.AspNetCore.Components.RenderTree;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 
 namespace BlazorBindings.Core
@@ -15,6 +16,7 @@ namespace BlazorBindings.Core
         private readonly Dictionary<int, NativeComponentAdapter> _componentIdToAdapter = new Dictionary<int, NativeComponentAdapter>();
         private ElementManager _elementManager;
         private readonly Dictionary<ulong, Action<ulong>> _eventRegistrations = new Dictionary<ulong, Action<ulong>>();
+        private readonly List<(int Id, IComponent Component)> _rootComponents = new();
 
 
         public NativeComponentRenderer(IServiceProvider serviceProvider, ILoggerFactory loggerFactory)
@@ -63,6 +65,8 @@ namespace BlazorBindings.Core
                     var component = InstantiateComponent(componentType);
                     var componentId = AssignRootComponentId(component);
 
+                    _rootComponents.Add((componentId, component));
+
                     var rootAdapter = new NativeComponentAdapter(this, closestPhysicalParent: parent, knownTargetElement: parent)
                     {
                         Name = $"RootAdapter attached to {parent.GetType().FullName}",
@@ -75,13 +79,21 @@ namespace BlazorBindings.Core
                     return component;
                 }).ConfigureAwait(false);
             }
-#pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
-#pragma warning restore CA1031 // Do not catch general exception types
             {
                 HandleException(ex);
                 return null;
             }
+        }
+
+        /// <summary>
+        /// Removes the specified component from the renderer, causing the component and its
+        /// descendants to be disposed.
+        /// </summary>
+        public void RemoveRootComponent(IComponent component)
+        {
+            var componentId = _rootComponents.LastOrDefault(c => c.Component == component).Id;
+            RemoveRootComponent(componentId);
         }
 
         protected override Task UpdateDisplayAsync(in RenderBatch renderBatch)

--- a/src/BlazorBindings.Maui/MauiAppBuilderExtensions.cs
+++ b/src/BlazorBindings.Maui/MauiAppBuilderExtensions.cs
@@ -18,7 +18,7 @@ namespace BlazorBindings.Maui
             builder.Services
                 .AddSingleton<Navigation>(svcs => new Navigation(svcs))
                 .AddSingleton<INavigation>(services => services.GetRequiredService<Navigation>())
-                .AddScoped<MauiBlazorBindingsRenderer>(svcs => new MauiBlazorBindingsRenderer(svcs, svcs.GetRequiredService<ILoggerFactory>()));
+                .AddSingleton<MauiBlazorBindingsRenderer>(svcs => new MauiBlazorBindingsRenderer(svcs, svcs.GetRequiredService<ILoggerFactory>()));
 
             return builder;
         }

--- a/src/BlazorBindings.Maui/MauiBlazorBindingsRenderer.cs
+++ b/src/BlazorBindings.Maui/MauiBlazorBindingsRenderer.cs
@@ -40,7 +40,7 @@ namespace BlazorBindings.Maui
 
                 if (!elementsComponentTask.IsCompleted && parent is MC.Application app)
                 {
-                    // MAUI requires the Application to have the MainPage. If rendering task is not completed synchroniously,
+                    // MAUI requires the Application to have the MainPage. If rendering task is not completed synchronously,
                     // we need to set MainPage to something.
                     app.MainPage ??= new MC.ContentPage();
                 }


### PR DESCRIPTION
Previously multiple scoped Renderers were used for navigation, and entire scope was disposed with renderer when navigated out. Now it uses single Renderer with multiple root components.