### PR TITLE
Fix EventCallback Net8.0

### DIFF
--- a/src/BlazorBindings.Core/NativeControlComponentBase.cs
+++ b/src/BlazorBindings.Core/NativeControlComponentBase.cs
@@ -3,6 +3,7 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
 using System.Security.Claims;
@@ -35,12 +36,12 @@ public abstract class NativeControlComponentBase : IComponent
     protected static bool Equals(EventCallback e1, object e2)
         => e2 is EventCallback other
         && ReferenceEquals(GetReceiver(e1), GetReceiver(other))
-        && Equals(GetDelegate(e2), GetDelegate(other));
+        && Equals(GetDelegate(e1), GetDelegate(other));
 
     protected static bool Equals<T>(EventCallback<T> e1, object e2)
         => e2 is EventCallback<T> other
         && ReferenceEquals(GetReceiver(e1), GetReceiver(other))
-        && Equals(GetDelegate(e2), GetDelegate(other));
+        && Equals(GetDelegate(e1), GetDelegate(other));
 
     protected virtual void BuildRenderTree(RenderTreeBuilder builder)
     {
@@ -173,28 +174,21 @@ public abstract class NativeControlComponentBase : IComponent
         }
     }
 
-    private static bool AreEqual(object callback1, object callback2)
-    {
-        // Retrieve the delegate (method) of both callbacks.
-        var delegate1 = GetDelegate(callback1);
-        var delegate2 = GetDelegate(callback2);
-
-        // Retrieve the receiver (the object the delegate is bound to) of both callbacks.
-        var receiver1 = GetReceiver(callback1);
-        var receiver2 = GetReceiver(callback2);
-
-        // Compare both the receiver and the delegate. They must both be equal for the callbacks to be considered equal.
-        return ReferenceEquals(receiver1, receiver2) && Equals(delegate1, delegate2);
-    }
-
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
-    extern static ref IHandleEvent GetReceiver(object obj);
-
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
-    extern static ref MulticastDelegate GetDelegate(object obj);
-
     void IComponent.Attach(RenderHandle renderHandle)
     {
         _renderHandle = renderHandle;
     }
+
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
+    extern static ref IHandleEvent GetReceiver(EventCallback callback);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
+    extern static IHandleEvent GetReceiver<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(EventCallback<T> e1);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
+    extern static ref MulticastDelegate GetDelegate(EventCallback callback);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
+    extern static MulticastDelegate GetDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(EventCallback<T> e1);
 }

--- a/src/BlazorBindings.Core/NativeControlComponentBase.cs
+++ b/src/BlazorBindings.Core/NativeControlComponentBase.cs
@@ -3,10 +3,8 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
-using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
-using System.Security.Claims;
 
 namespace BlazorBindings.Core;
 
@@ -33,11 +31,14 @@ public abstract class NativeControlComponentBase : IComponent
         return Task.CompletedTask;
     }
 
+    // Equals methods are overridden only as a workaround to this issue:
+    // https://github.com/dotnet/aspnetcore/issues/53361
     protected static bool Equals(EventCallback e1, object e2)
         => e2 is EventCallback other
         && ReferenceEquals(GetReceiver(ref e1), GetReceiver(ref other))
         && Equals(GetDelegate(ref e1), GetDelegate(ref other));
 
+    // TODO: uncomment on dotnet9.0
     //protected static bool Equals<T>(EventCallback<T> e1, object e2)
     //    => e2 is EventCallback<T> other
     //    && ReferenceEquals(GetReceiver(ref e1), GetReceiver(ref other))
@@ -187,6 +188,7 @@ public abstract class NativeControlComponentBase : IComponent
     extern static ref MulticastDelegate GetDelegate(ref EventCallback _this);
 
     // Unfortunately can't use with generics https://github.com/dotnet/runtime/issues/89439
+    // TODO: uncomment on dotnet9.0
 
     //[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
     //extern static ref IHandleEvent GetReceiver<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ref EventCallback<T> _this);

--- a/src/BlazorBindings.Core/NativeControlComponentBase.cs
+++ b/src/BlazorBindings.Core/NativeControlComponentBase.cs
@@ -3,7 +3,9 @@
 
 using Microsoft.AspNetCore.Components;
 using Microsoft.AspNetCore.Components.Rendering;
+using System.Runtime.CompilerServices;
 using System.Runtime.ExceptionServices;
+using System.Security.Claims;
 
 namespace BlazorBindings.Core;
 
@@ -29,6 +31,16 @@ public abstract class NativeControlComponentBase : IComponent
         StateHasChanged();
         return Task.CompletedTask;
     }
+
+    protected static bool Equals(EventCallback e1, object e2)
+        => e2 is EventCallback other
+        && ReferenceEquals(GetReceiver(e1), GetReceiver(other))
+        && Equals(GetDelegate(e2), GetDelegate(other));
+
+    protected static bool Equals<T>(EventCallback<T> e1, object e2)
+        => e2 is EventCallback<T> other
+        && ReferenceEquals(GetReceiver(e1), GetReceiver(other))
+        && Equals(GetDelegate(e2), GetDelegate(other));
 
     protected virtual void BuildRenderTree(RenderTreeBuilder builder)
     {
@@ -160,6 +172,26 @@ public abstract class NativeControlComponentBase : IComponent
             HandleException(ex);
         }
     }
+
+    private static bool AreEqual(object callback1, object callback2)
+    {
+        // Retrieve the delegate (method) of both callbacks.
+        var delegate1 = GetDelegate(callback1);
+        var delegate2 = GetDelegate(callback2);
+
+        // Retrieve the receiver (the object the delegate is bound to) of both callbacks.
+        var receiver1 = GetReceiver(callback1);
+        var receiver2 = GetReceiver(callback2);
+
+        // Compare both the receiver and the delegate. They must both be equal for the callbacks to be considered equal.
+        return ReferenceEquals(receiver1, receiver2) && Equals(delegate1, delegate2);
+    }
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
+    extern static ref IHandleEvent GetReceiver(object obj);
+
+    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
+    extern static ref MulticastDelegate GetDelegate(object obj);
 
     void IComponent.Attach(RenderHandle renderHandle)
     {

--- a/src/BlazorBindings.Core/NativeControlComponentBase.cs
+++ b/src/BlazorBindings.Core/NativeControlComponentBase.cs
@@ -35,13 +35,13 @@ public abstract class NativeControlComponentBase : IComponent
 
     protected static bool Equals(EventCallback e1, object e2)
         => e2 is EventCallback other
-        && ReferenceEquals(GetReceiver(e1), GetReceiver(other))
-        && Equals(GetDelegate(e1), GetDelegate(other));
+        && ReferenceEquals(GetReceiver(ref e1), GetReceiver(ref other))
+        && Equals(GetDelegate(ref e1), GetDelegate(ref other));
 
-    protected static bool Equals<T>(EventCallback<T> e1, object e2)
-        => e2 is EventCallback<T> other
-        && ReferenceEquals(GetReceiver(e1), GetReceiver(other))
-        && Equals(GetDelegate(e1), GetDelegate(other));
+    //protected static bool Equals<T>(EventCallback<T> e1, object e2)
+    //    => e2 is EventCallback<T> other
+    //    && ReferenceEquals(GetReceiver(ref e1), GetReceiver(ref other))
+    //    && Equals(GetDelegate(ref e1), GetDelegate(ref other));
 
     protected virtual void BuildRenderTree(RenderTreeBuilder builder)
     {
@@ -181,14 +181,16 @@ public abstract class NativeControlComponentBase : IComponent
 
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
-    extern static ref IHandleEvent GetReceiver(EventCallback callback);
-
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
-    extern static IHandleEvent GetReceiver<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(EventCallback<T> e1);
+    extern static ref IHandleEvent GetReceiver(ref EventCallback _this);
 
     [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
-    extern static ref MulticastDelegate GetDelegate(EventCallback callback);
+    extern static ref MulticastDelegate GetDelegate(ref EventCallback _this);
 
-    [UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
-    extern static MulticastDelegate GetDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(EventCallback<T> e1);
+    // Unfortunately can't use with generics https://github.com/dotnet/runtime/issues/89439
+
+    //[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Receiver")]
+    //extern static ref IHandleEvent GetReceiver<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ref EventCallback<T> _this);
+
+    //[UnsafeAccessor(UnsafeAccessorKind.Field, Name = "Delegate")]
+    //extern static ref MulticastDelegate GetDelegate<[DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.All)] T>(ref EventCallback<T> _this);
 }


### PR DESCRIPTION
During testing of the library, I discovered that `EventCallbacks` in `.NET 8` are not invoking the `Equals` method correctly, which is documented in this [issue](https://github.com/dotnet/aspnetcore/issues/53361). For instance, setting the `OnLoaded` `EventCallback` triggers an infinite loop as it continually sets and unsets the callback. This behavior also occurs with other callbacks, such as `OnClick`.

To work around this issue, I implemented a utility class to compare `EventCallback` instances. While this is a temporary solution, it appears necessary as the two properties required to check equality are internal, and the fix has been moved to `.NET 10` as noted in the issue.
